### PR TITLE
👌 Move useragent to label

### DIFF
--- a/pkg/endpoints/metrics/metric_handler.go
+++ b/pkg/endpoints/metrics/metric_handler.go
@@ -15,7 +15,7 @@ import (
 )
 
 func generateMetricHandler(cfg config.Config, logger *logrus.Logger) (gin.HandlerFunc, endpoints.TeardownFn) {
-	counters := NewMetricRegistry(cfg.LegalAgents)
+	counters := NewMetricRegistry()
 
 	counters.Add(commandExecutionDefinition)
 

--- a/pkg/endpoints/metrics/types.go
+++ b/pkg/endpoints/metrics/types.go
@@ -1,5 +1,7 @@
 package metrics
 
+const defaultMetricNamespace = "okctl"
+
 // Event defines information necessary to process a metric event
 type Event struct {
 

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -177,7 +177,7 @@ func TestAtoB(t *testing.T) {
 				},
 			},
 			expectHit: hit{
-				Key:   `okctl_commandexecution_scaffoldcluster{phase="start"}`,
+				Key:   `okctl_commandexecution_scaffoldcluster{phase="start",useragent="okctl"}`,
 				Value: 1,
 			},
 		},
@@ -201,7 +201,7 @@ func TestAtoB(t *testing.T) {
 				},
 			},
 			expectHit: hit{
-				Key:   `okctl_commandexecution_scaffoldcluster{phase="start"}`,
+				Key:   `okctl_commandexecution_scaffoldcluster{phase="start",useragent="okctl"}`,
 				Value: 3,
 			},
 		},
@@ -215,7 +215,7 @@ func TestAtoB(t *testing.T) {
 				},
 			},
 			expectHit: hit{
-				Key:   `okctl_commandexecution_showcredentials{phase="start"}`,
+				Key:   `okctl_commandexecution_showcredentials{phase="start",useragent="okctl"}`,
 				Value: 1,
 			},
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a useragent label to each metrics for a cleaner metrics query interface

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Realised user agent makes more sense as a label

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
Run the server with BASE_URL=http://localhost go run main.go
Make a request to the service with okctl and okctldev as user-agents. For example like this:
```shell
curl http://localhost:3000/v1/metrics/events \
    -X POST \
    -H "User-Agent: okctl" \
    -H "Content-Type: application/json" \
    -d '{"category": "commandexecution", "action": "scaffoldcluster", "labels":{"phase": "start"}}'

curl http://localhost:3000/v1/metrics/events \
    -X POST \
    -H "User-Agent: okctldev" \
    -H "Content-Type: application/json" \
    -d '{"category": "commandexecution", "action": "scaffoldcluster", "labels":{"phase": "start"}}'
```

Check http://localhost:3000/z/prometheus and confirm that the two metrics are identically named with different labels

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
